### PR TITLE
Fix an issue where we couldn't pass commit messages with '-m'

### DIFF
--- a/git-map
+++ b/git-map
@@ -35,5 +35,5 @@ if [ $? -eq 0 ] ; then
 fi
 for dir in $(find . -maxdepth 2 -type d -name .git -prune -exec dirname '{}' \;); do
   echo "Running \"git $@\" in ${dir}";
-  (cd ${dir}; git $@) || exit $?
+  (cd ${dir}; git "$@") || exit $?
 done


### PR DESCRIPTION
Just ran into the following issue:
```
~/dev/ git map commit -a -m "This is a test commit"
Running "git commit -a -m This is a test commit" in ./project1
fatal: Paths with -a does not make sense.
````
Adding quotes around the passing parameters would have this fixed.